### PR TITLE
remove cassandra consistency options from yaml example

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -252,9 +252,6 @@ cassandra:
   clusterName: &quot;test&quot;
   contactPoints: [&quot;127.0.0.1&quot;]
   keyspace: reaper_db
-  queryOptions:
-    consistencyLevel: LOCAL_QUORUM
-    serialConsistencyLevel: SERIAL
 </code></pre>
 
 <p>When using SSL:</p>


### PR DESCRIPTION
In the yaml file the consistency options in the `queryOptions` section for cassandra were removed with the ft branch.
(Consistency settings are determined by the design, not by the user/operator)